### PR TITLE
fix: Standardize date format for transactions

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -228,7 +228,7 @@ function getTransactions() {
     transactions.push({
       row: i + 1, // Add row number for editing/deleting
       transactionId: data[i][0],
-      date: new Date(data[i][1]),
+      date: new Date(data[i][1]).toISOString(),
       type: data[i][2],
       category: data[i][3],
       amount: data[i][4],


### PR DESCRIPTION
The transaction history was not displaying due to inconsistent date serialization from the Google Apps Script backend.

This commit modifies the `getTransactions` function to return dates as ISO 8601 strings, ensuring they are correctly parsed by the frontend JavaScript.